### PR TITLE
fix: use Equinix red for top nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,11 +19,11 @@ nav:
 
 theme:
   name: material
-
   palette:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
+      primary: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
@@ -31,6 +31,7 @@ theme:
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
+      primary: custom
       toggle:
         icon: material/brightness-4
         name: Switch to light mode


### PR DESCRIPTION
We already have custom CSS to override the nav bar color, but it doesn't take effect for most of our sites (it's unclear why the color shows up on the Terraform on Equinix workshop pages; the configuration looks identical).

Note that the `custom` color scheme had to be specified twice, once for light mode and once for dark mode.

Fixes #10